### PR TITLE
#168781826 mark all notification as read

### DIFF
--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -31,6 +31,16 @@ const NotificationController = {
       'Notification status updated!'
     );
   },
+
+  async markAllNotificationsAsRead(req, res) {
+    const { userId } = req.userData;
+    await NotificationService.markAllAsRead(userId);
+    return sendResult(
+      res,
+      200,
+      'All notifications are marked as read',
+    );
+  }
 };
 
 export default NotificationController;

--- a/src/routes/notification.route.js
+++ b/src/routes/notification.route.js
@@ -8,11 +8,12 @@ const app = express.Router();
 const { checkToken } = UserMiddleware;
 const { checkNotificationExists, checkNotificationOwner } = NotificationMiddleware;
 const {
-  getUserNotifications, updateNotificationStatus, getSingleNotification,
+  getUserNotifications, updateNotificationStatus, getSingleNotification, markAllNotificationsAsRead
 } = NotificationController;
 
 app.get('/', checkToken, getUserNotifications);
 app.get('/:id', checkToken, checkNotificationExists, checkNotificationOwner, getSingleNotification);
 app.patch('/:id/:status', checkToken, checkNotificationExists, checkNotificationOwner, updateNotificationStatus);
+app.patch('/readall', checkToken, markAllNotificationsAsRead);
 
 export default app;

--- a/src/services/notifications.service.js
+++ b/src/services/notifications.service.js
@@ -7,6 +7,7 @@ const NotificationService = {
   createNotification: async (notification) => db.Notifications.create(notification, { raw: true }),
   setNotificationStatus: async (id, isRead) => db.Notifications
     .update({ isRead }, { where: { id } }),
+  markAllAsRead: async (userId) => db.Notifications.update({ isRead: true }, { where: { userId } }),
 };
 
 export default NotificationService;

--- a/src/tests/request.post.spec.js
+++ b/src/tests/request.post.spec.js
@@ -96,3 +96,15 @@ describe('create request and new request notifications', () => {
       });
   });
 });
+
+describe('PATCH /notifications/all', () => {
+  it('should return a 201 status when all notification are marked as read', (done) => {
+    chai.request(app)
+      .patch('/api/v1/notifications/readall')
+      .set('Authorization', helper.createToken(5, 'manager@gmail.com', true, 'manager'))
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
          this PR allows a user to mark all the notification as read
#### Description of Task to be completed?
          this PR gives a user ability a clean his/her notification panel by marking all the notifications as read
#### How should this be manually tested?
        

- clone this PR 

- run `npm run db-migrate:dev`

- run `npm run dev` and then in the postman send 

> PATCH /notifications/read

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
          #168781826 
#### Screenshots (if appropriate)
           
<img width="885" alt="Screen Shot 2019-11-06 at 16 33 05" src="https://user-images.githubusercontent.com/39420985/68306979-2d74d980-00b3-11ea-9bf5-4c1d96095c46.png">

#### Questions:
           N/A