### PR TITLE
#169645673 accommodation likes statistics

### DIFF
--- a/src/controllers/likings.controller.js
+++ b/src/controllers/likings.controller.js
@@ -10,6 +10,16 @@ const LikingsController = {
     } catch (error) {
       return sendResult(res, 400, 'Wrong accommodation ID sent');
     }
+  },
+
+  async getAccommdationLikes(req, res) {
+    try {
+      const { accommodationId } = req.params;
+      const number = await LikingService.getLikes(accommodationId);
+      return sendResult(res, 200, ` The ccommodation ${accommodationId} has:  ${number.likes} likes `, number);
+    } catch (error) {
+      return sendResult(res, 400, 'Wrong accommodation ID sent');
+    }
   }
 };
 

--- a/src/routes/accommodationRoute.js
+++ b/src/routes/accommodationRoute.js
@@ -32,6 +32,10 @@ app.post('/:accommodationId/like', [
   checkToken,
   LikingsController.addLikeAccommdation
 ]);
+app.get('/:accommodationId/like', [
+  checkToken,
+  LikingsController.getAccommdationLikes
+]);
 
 
 export default app;

--- a/src/services/liking.service.js
+++ b/src/services/liking.service.js
@@ -13,6 +13,17 @@ const LikingService = {
     }
     like.update({ isLiked: !like.isLiked });
     return sendResult(res, 200, ` The accommodation like  status updated to ${like.isLiked}`, like);
+  },
+
+  async getLikes(accommodationId) {
+    const countLikes = await db.Likings
+      .findAndCountAll({ where: { accommodationId, isLiked: true }, raw: false });
+    const countUnlikes = await db.Likings
+      .findAndCountAll({ where: { accommodationId, isLiked: false }, raw: false });
+    const data = {
+      likes: countLikes.count + countUnlikes.count,
+    };
+    return data;
   }
 };
 export default LikingService;

--- a/src/tests/liking.accommodation.spec.js
+++ b/src/tests/liking.accommodation.spec.js
@@ -67,4 +67,22 @@ describe('Like/Unlike an accomodation facility', () => {
         done();
       });
   });
+  it('it should return 200  and count the unlikes and likes of the accommodation', (done) => {
+    chai.request(app)
+      .get('/api/v1/accommodations/2/like')
+      .set('Authorization', helper.createToken(2, 'requester@gmail.com', true, 'requester'))
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+  it('it should return 400 status when wront accommodation sumber is sent', (done) => {
+    chai.request(app)
+      .get('/api/v1/accommodations/dgsd/like')
+      .set('Authorization', helper.createToken(2, 'requester@gmail.com', true, 'requester'))
+      .end((err, res) => {
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?

- As a user, I can see the likes/unlikes of an accommodation facility

#### Description of Task to be completed?
 - Once a user logged into the barefoot nomad, he/she can see the number of accommodation likes/unlikes

#### How should this be manually tested?

- test this `get` route: `api/v1/accommodations/accommodationId/like`

#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?

[Pivotal story](https://www.pivotaltracker.com/story/show/169645673)

#### Screenshots (if appropriate)

<img width="814" alt="Screen Shot 2019-11-08 at 16 34 50" src="https://user-images.githubusercontent.com/48722615/68484389-d9e6c500-0245-11ea-9471-b07440bef2f0.png">

#### Questions: