### PR TITLE
#169649552 notification status

### DIFF
--- a/src/controllers/notifications.controller.js
+++ b/src/controllers/notifications.controller.js
@@ -22,13 +22,12 @@ const NotificationController = {
   },
 
   async updateNotificationStatus(req, res) {
-    const { id, status } = req.params;
-    const isRead = (status === 'read');
-    await NotificationService.setNotificationStatus(id, isRead);
+    const { id, isRead } = req.notification;
+    await NotificationService.setNotificationStatus(id, !(isRead));
     return sendResult(
       res,
       200,
-      'Notification status updated!'
+      `Notification status updated to ${!(isRead)}!`
     );
   },
 

--- a/src/routes/notification.route.js
+++ b/src/routes/notification.route.js
@@ -2,6 +2,7 @@ import express from 'express';
 import UserMiddleware from '../middlewares/userMiddlware';
 import NotificationMiddleware from '../middlewares/notification.middleware';
 import NotificationController from '../controllers/notifications.controller';
+import Validation from '../validation';
 
 const app = express.Router();
 
@@ -10,10 +11,11 @@ const { checkNotificationExists, checkNotificationOwner } = NotificationMiddlewa
 const {
   getUserNotifications, updateNotificationStatus, getSingleNotification, markAllNotificationsAsRead
 } = NotificationController;
+const { idValidate } = Validation;
 
 app.get('/', checkToken, getUserNotifications);
 app.get('/:id', checkToken, checkNotificationExists, checkNotificationOwner, getSingleNotification);
-app.patch('/:id/:status', checkToken, checkNotificationExists, checkNotificationOwner, updateNotificationStatus);
+app.patch('/:id/status', idValidate, checkToken, checkNotificationExists, checkNotificationOwner, updateNotificationStatus);
 app.patch('/readall', checkToken, markAllNotificationsAsRead);
 
 export default app;

--- a/src/tests/request.post.spec.js
+++ b/src/tests/request.post.spec.js
@@ -78,7 +78,7 @@ describe('create request and new request notifications', () => {
   });
   it('should return a 200 status when notification is updated to read', (done) => {
     chai.request(app)
-      .patch('/api/v1/notifications/1/read')
+      .patch('/api/v1/notifications/1/status')
       .set('Authorization', helper.createToken(5, 'manager@gmail.com', true, 'manager'))
       .end((err, res) => {
         expect(res.status).to.equal(200);


### PR DESCRIPTION
#### What does this PR do?
- Mark a notification as read or unread
#### Description of Task to be completed?
This will allow a user to mark a notification as read or unread by passing into params
#### How should this be manually tested?
to make a notification as read, you simply need to pass the details of it. inside a route itself:
PATCH:`api/v1/notification/:id/status` *e.g: /api/v1/notifications/2/status*
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[story](https://www.pivotaltracker.com/story/show/169649552)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A