### PR TITLE
refactor likes

### DIFF
--- a/src/controllers/likings.controller.js
+++ b/src/controllers/likings.controller.js
@@ -15,8 +15,8 @@ const LikingsController = {
   async getAccommdationLikes(req, res) {
     try {
       const { accommodationId } = req.params;
-      const number = await LikingService.getLikes(accommodationId);
-      return sendResult(res, 200, ` The ccommodation ${accommodationId} has:  ${number} likes `, number);
+      const likes = await LikingService.getLikes(accommodationId);
+      return sendResult(res, 200, 'likes', likes);
     } catch (error) {
       return sendResult(res, 400, 'Wrong accommodation ID sent');
     }

--- a/src/services/liking.service.js
+++ b/src/services/liking.service.js
@@ -16,9 +16,8 @@ const LikingService = {
   },
 
   async getLikes(accommodationId) {
-    const countLikes = await db.Likings
-      .count({ where: { accommodationId, isLiked: true }, raw: false });
-    return countLikes;
+    return db.Likings
+      .findAll({ where: { accommodationId, isLiked: true }, raw: false });
   }
 };
 export default LikingService;

--- a/src/tests/liking.accommodation.spec.js
+++ b/src/tests/liking.accommodation.spec.js
@@ -73,11 +73,11 @@ describe('Like/Unlike an accomodation facility', () => {
       .set('Authorization', helper.createToken(2, 'requester@gmail.com', true, 'requester'))
       .end((err, res) => {
         expect(res.status).to.equal(200);
-        expect(res.body.data).to.equal(3);
+        expect(res.body.data.length).to.equal(3);
         done();
       });
   });
-  it('it should return 400 status when wront accommodation sumber is sent', (done) => {
+  it('it should return 400 status when wrong accommodation sumber is sent', (done) => {
     chai.request(app)
       .get('/api/v1/accommodations/dgsd/like')
       .set('Authorization', helper.createToken(2, 'requester@gmail.com', true, 'requester'))


### PR DESCRIPTION
#### What does this PR do?
Refactor likes to send the users who liked the accommodation
#### Description of Task to be completed?
The routes of getting likes should send users who liked accommodation instead of
sending a number
#### How should this be manually tested?
Run `npm test`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions: