### PR TITLE
#170310982: retrieve comment in descending order

### DIFF
--- a/src/services/comment.service.js
+++ b/src/services/comment.service.js
@@ -19,18 +19,24 @@ const CommentService = {
   },
   async getReplies(id) {
     const replies = await db.Comments.findAll({
-      where: { parent: id },
+      where: { parent: id, deletedAt: null },
       attributes: { exclude: ['updatedAt', 'requestId', 'deletedAt', 'parent'] },
       include: [{ model: db.Users, attributes: ['RoleId', 'fullname'] }],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
       raw: true
     });
     return replies;
   },
   async getComments(requestId) {
     const result = await db.Comments.findAll({
-      where: { requestId, parent: null },
+      where: { requestId, parent: null, deletedAt: null },
       attributes: { exclude: ['updatedAt', 'requestId', 'deletedAt', 'parent'] },
       include: [{ model: db.Users, attributes: ['RoleId', 'fullname'] }],
+      order: [
+        ['createdAt', 'DESC'],
+      ],
       raw: true
     });
     for (const [key, value] of Object.entries(result)) {

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -44,14 +44,14 @@ const validator = {
 
   accommodation(req, res, next) {
     try {
-      new Check({ name: req }).str().req().min(5);
+      new Check({ name: req }).str().req().min(1);
       new Check({ description: req }).str().req().min(5);
       new Check({ address: req }).str().req().min(5);
       new Check({ availableSpace: req }).str().req().min(5);
       new Check({ cost: req }).req().double();
       new Check({ currency: req }).str().eql(3);
       new Check({ services: req }).str().req().min(5);
-      new Check({ amenities: req }).str().req().min(5);
+      new Check({ amenities: req }).str().req().min(3);
       req.body.cost = parseFloat(req.body.cost);
       if (req.body.currency) {
         const found = Object.keys(currencies)


### PR DESCRIPTION
#### What does this PR do?
          reverse comment order
#### Description of Task to be completed?
           order comment in descending 
#### How should this be manually tested?
        -  clone this repo
        - login first
       - navigate to `localhost:3000/api/v1/request/:id/comment`
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
           #170310982
#### Screenshots (if appropriate)
#### Questions: